### PR TITLE
Update manager_action_attack_custom.lua

### DIFF
--- a/scripts/manager_action_attack_custom.lua
+++ b/scripts/manager_action_attack_custom.lua
@@ -654,7 +654,7 @@ function checkCanThreaten(nodeActorCT, nodeTargetCT)
 	-- https://www.aonprd.com/FeatDisplay.aspx?ItemName=Snap%20Shot
 	local rActorCT = ActorManager.resolveActor(nodeActorCT);
 	local nodeActor = ActorManager.getCreatureNode(nodeActorCT);
-	if ActorManager.isPC(rActorCT) then
+	if ActorManager.isPC(rActorCT) and nodeActor ~= nil then
 		for _,nodeWeapon in pairs(nodeActor.getChild('.weaponlist').getChildren()) do
 			if (DB.getValue(nodeWeapon, 'carried', 0) == 2) and (DB.getValue(nodeWeapon, 'type', 0) == 0) then
 				return true;


### PR DESCRIPTION
Check that the return from ActorManager.getCreatureNode(nodeActorCT) is not nil.  It will be if the attacking player doesn't own the character referenced by nodeActorCT.