### PR TITLE
Advanced Effects Integration

### DIFF
--- a/scripts/manager_action_attack_custom.lua
+++ b/scripts/manager_action_attack_custom.lua
@@ -102,7 +102,7 @@ end
 function getRangeModifier(rSource, rRoll, nRange)
 	-- Get the range penalty based on the distance to target and weapon used
 
-	local srcNode = rSource.sCreatureNode;
+	local srcNode = ActorManager.getCreatureNode(rSource);
 
 	-- Get the name of the weapon being used
 	local sWeaponUsed = string.match(rRoll.sDesc, "%]([^%[]*)");

--- a/scripts/manager_action_attack_custom.lua
+++ b/scripts/manager_action_attack_custom.lua
@@ -146,7 +146,7 @@ function getRangeModifier(rSource, rRoll, nRange)
 		-- For an NPC, get the standard range data for the weapon type
 		-- Check for a match against the weapon data
 		local tWeaponRangeData = DataCommonCMC.weaponranges[sWeaponUsed];
-		if tWeaponRangeData == nil then
+		if not tWeaponRangeData then
 			-- It wasn't found; check for a match vs each entry in the
 			-- data table in case this weapon has additional words (Mwk, silver, etc.)
 			for sWeaponName, tWeaponRangeData in pairs(DataCommonCMC.weaponranges) do
@@ -154,6 +154,18 @@ function getRangeModifier(rSource, rRoll, nRange)
 					nRangeInc = tWeaponRangeData[1];
 					nMaxInc = tWeaponRangeData[2];
 					break;
+				end
+			end
+			-- It still wasn't found; check for rSource.nodeWeapon (from Advanced Effects).
+			-- If found, get range increment from the item record.
+			if nRangeInc == 0 and nMaxInc == 0 then
+				if rSource.nodeWeapon then
+					local nodeWeapon = DB.findNode(rSource.nodeWeapon)
+					if nodeWeapon then
+						nRangeInc = DB.getValue(nodeWeapon, 'range', 0);
+						nMaxInc = 10;
+						Debug.console(Interface.getString('cmc_nomaxrangeinc_ae'))
+					end
 				end
 			end
 		else

--- a/scripts/manager_action_attack_custom.lua
+++ b/scripts/manager_action_attack_custom.lua
@@ -179,7 +179,7 @@ function getRangeModifier(rSource, rRoll, nRange)
 	
 	-- Issue warning if beyond maximum range
 	if nInc > nMaxInc then
-		local tMsg = {sender = "", font = "emotefont", mood = "ooc"};
+		local tMsg = {sender = rSource.sName, font = "emotefont", mood = "ooc"};
 		local nMaxRange = nMaxInc * nRangeInc;
 		tMsg.text = "Range " .. nRange .. " is beyond the " .. sWeaponUsed .. "'s maximum of " .. nMaxRange;
 		Comm.deliverChatMessage(tMsg);

--- a/scripts/manager_action_attack_custom.lua
+++ b/scripts/manager_action_attack_custom.lua
@@ -257,7 +257,7 @@ function checkShootMelee(rSource, srcNode, rTarget)
 				-- -2 if the target is two size categories larger than adjacent friendly
 				-- no penalty if target 3+ sizes larger than adjacent friendly
 				if bCheck and checkCanThreaten(adjActor, rTarget.sCTNode) then
-					nSizeDiff = tgtSize - adjSize;
+					local nSizeDiff = tgtSize - adjSize;
 					if nSizeDiff < 2 then
 						return -4;
 					elseif nSizeDiff == 2 then

--- a/scripts/manager_action_attack_custom.lua
+++ b/scripts/manager_action_attack_custom.lua
@@ -55,7 +55,7 @@ function modAttackCustom(rSource, rTarget, rRoll, ...)
 		removeEffect(srcCTnode, "Flanking");
 		if rTarget ~= nil then
 			-- Check range modifier
-			local nRangeMod = getRangeModifier(srcNode, rRoll, nRange);
+			local nRangeMod = getRangeModifier(rSource, rRoll, nRange);
 			if nRangeMod < 0 then
 				rRoll.sDesc = rRoll.sDesc .. " " .. "[RANGE " .. nRangeMod .."]";
 				rRoll.nMod = rRoll.nMod + nRangeMod;
@@ -99,9 +99,11 @@ function getRangeToTarget(rSource, rTarget)
 	
 end
 
-function getRangeModifier(srcNode, rRoll, nRange)
+function getRangeModifier(rSource, rRoll, nRange)
 	-- Get the range penalty based on the distance to target and weapon used
 	
+	local srcNode = rSource.sCreatureNode;
+
 	-- Get the name of the weapon being used
 	local sWeaponUsed = string.match(rRoll.sDesc, "%]([^%[]*)");
 	sWeaponUsed = StringManager.trim(sWeaponUsed):lower();

--- a/scripts/manager_action_attack_custom.lua
+++ b/scripts/manager_action_attack_custom.lua
@@ -90,7 +90,7 @@ function getRangeToTarget(rSource, rTarget)
 	-- Returns the range from source to target
 	
 	-- are we on a gridded map?
-	local srcToken, tgtToken, srcImage, tgtImage = getTokensMaps(rSource, rTarget);
+	local srcToken, tgtToken = getTokensMaps(rSource, rTarget);
 	if srcToken == nil then
 		return -1;
 	end
@@ -101,7 +101,7 @@ end
 
 function getRangeModifier(rSource, rRoll, nRange)
 	-- Get the range penalty based on the distance to target and weapon used
-	
+
 	local srcNode = rSource.sCreatureNode;
 
 	-- Get the name of the weapon being used
@@ -129,7 +129,7 @@ function getRangeModifier(rSource, rRoll, nRange)
 				end
 				-- The weapon record does not include the item subtype, which we need to figure out
 				-- the maximum number of range increments.  For that, we need the inventory record.
-				local sClass, sRecordName = DB.getValue(vWeaponNode, "shortcut");
+				local _, sRecordName = DB.getValue(vWeaponNode, "shortcut");
 				local vInvNode = DB.findNode(sRecordName);
 				if vInvNode ~= nil then
 					local sSubType = DB.getValue(vInvNode, "subtype", "");
@@ -173,7 +173,7 @@ function getRangeModifier(rSource, rRoll, nRange)
 			nMaxInc = tWeaponRangeData[2];
 		end
 	end
-	
+
 	if nMaxInc == 0 or nRangeInc == 0 then
 		-- Weapon wasn't found.  Maybe it is a spell or special ability?
 		if hasSpell(srcNode, sWeaponUsed) then
@@ -181,14 +181,13 @@ function getRangeModifier(rSource, rRoll, nRange)
 		end
 		-- Give a warning in Chat
 		local tMsg = {sender = "", font = "emotefont", mood = "ooc"};
-		local nMaxRange = nMaxInc * nRangeInc;
 		tMsg.text = "Weapon " .. sWeaponUsed .. " not found";
 		Comm.deliverChatMessage(tMsg);
 		return 0;
 	end
-	
+
 	local nInc = math.ceil(nRange / nRangeInc);
-	
+
 	-- Issue warning if beyond maximum range
 	if nInc > nMaxInc then
 		local tMsg = {sender = rSource.sName, font = "emotefont", mood = "ooc"};
@@ -196,13 +195,13 @@ function getRangeModifier(rSource, rRoll, nRange)
 		tMsg.text = "Range " .. nRange .. " is beyond the " .. sWeaponUsed .. "'s maximum of " .. nMaxRange;
 		Comm.deliverChatMessage(tMsg);
 	end
-	
+
 	local nRngMod = -2;
 	if hasFeat(srcNode, "Far Shot") then
 		nRngMod = -1;
 	end
 	return (nInc - 1) * nRngMod;
-	
+
 end
 
 function checkShootMelee(rSource, srcNode, rTarget)
@@ -242,7 +241,7 @@ function checkShootMelee(rSource, srcNode, rTarget)
 		tgtCoord.x, tgtCoord.y = tgtToken.getPosition();
 	else
 		-- figure out which square of the target is closest to source
-		tgtCoord.x, tgtCoord.y = getClosestTargetSquare(rTarget, srcToken, tgtToken, tgtSpace, tgtImage);
+		tgtCoord.x, tgtCoord.y = getClosestTargetSquare(rTarget, srcToken, tgtToken, tgtImage);
 	end
 	
 	local adjTokens = srcImage.getTokensWithinDistance({x=tgtCoord.x, y=(tgtCoord.y * -1)}, 5);
@@ -284,7 +283,7 @@ function checkShootMelee(rSource, srcNode, rTarget)
 	
 end
 
-function getClosestTargetSquare(rTarget, srcToken, tgtToken, tgtSpace, tgtImage)
+function getClosestTargetSquare(rTarget, srcToken, tgtToken, tgtImage)
 	-- return the X,Y of the center of the closest square of tgtToken from srcToken
 	
 	local tgtEdges = getTokenEdgeSquares(rTarget, tgtToken, tgtImage)
@@ -332,7 +331,7 @@ function checkFlanked(rSource, srcNode, rTarget)
 	if OptionsManager.isOption('AUTO_FLANK', 'on') then
 		-- Some creatures can't be flanked; some can be flanked (for purposes of Sneak Attack) but
 		-- ignore the +2 bonus
-		local bIgnoreFlank, bIgnoreBonus = checkCanBeFlanked(rSource, rTarget);
+		local bIgnoreFlank = checkCanBeFlanked(rSource, rTarget);
 		if bIgnoreFlank then
 			return false;
 		end
@@ -427,7 +426,7 @@ function checkCanBeFlanked(rSource, rTarget)
 	-- subtype "swarm"
 	if bTgtPC == false then
 		local vTgtNode = ActorManager.getCreatureNode(rTarget);
-		local sTgtType = DB.getValue(vTgtNode, "type");
+		-- local sTgtType = DB.getValue(vTgtNode, "type");
 		-- Debug.chat("sTgtType:  ", sTgtType);
 		if string.match(DB.getValue(vTgtNode, "type"):lower(), "swarm") then
 			return true, false;
@@ -475,7 +474,7 @@ function getMeleeThreats(srcToken, tgtToken, sSourceFaction)
 		local rNearActorCT = CombatManager.getCTFromToken(checkToken);
 		-- Debug.chat("rNearActorCT:  ", rNearActorCT, DB.getValue(ActorManager.getCTNode(rNearActorCT), "name"));
 		if rNearActorCT then
-			local nNearSize = ActorCommonManager.getCreatureSizeFromTypeFieldCore(rNearActorCT);
+			--local nNearSize = ActorCommonManager.getCreatureSizeFromTypeFieldCore(rNearActorCT);
 			local nNearReach = DB.getValue(ActorManager.getCTNode(rNearActorCT), "reach");
 			-- Ignore if threat is self
 			if checkToken ~= srcToken then
@@ -563,7 +562,7 @@ function getTokenBounds(rActor, theToken, tknImage)
 	
 	local nGrid = GameSystem.getDistanceUnitsPerGrid(); -- for 3.5E this is 5
 	local nGridSize = tknImage.getGridSize();  -- usually 50
-	local nHalfGrid = nGridSize / 2;
+	--local nHalfGrid = nGridSize / 2;
 	local tgtSide = tgtSpace / nGrid;  -- number of squares per side of the target token
 	
 	return {

--- a/strings/strings.xml
+++ b/strings/strings.xml
@@ -11,4 +11,6 @@
 	<string name="modifier_label_ATT_MELEE">Melee</string>
 	<!-- Options -->
 	<string name="opt_lab_autoflank">Automatic Flanking</string>
+	<!-- Debug Console -->
+	<string name="cmc_nomaxrangeinc_ae">Getting range increment from Advanced Effects; max range increment unavailable. Assuming 10.</string>
 </root>


### PR DESCRIPTION
When Advanced Effects for Pathfinder is being used, rSource contains a link to the item node of the weapon being used.
While the item node does not usually contain the max range increment, it typically does contain the normal range increment.
Along with some cleanup, this PR gets the weapon range from the item node if not found via the usual means (the lookup table).